### PR TITLE
Add conormcd/clj-honeycomb

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ If you'd like to add your own project, please file a pull request doing so.
 | heroku-buildpack-nginx | Fork of Heroku nginx that detects honeytail | https://github.com/nomics-crypto/heroku-buildpack-nginx |
 | digital-rebar-honeycomb | Plugin for Digital Rebar Provision (linked) that forwards system events and logs to Honeycomb.io account for observation.  Maintained by RackN.com | https://github.com/digitalrebar/provision |
 | honeycomb-ae-event | Wrapper for Golang http.HandleFunc for use with Google App Engine Standard | https://github.com/seanhagen/honeycomb-ae-event |
+| clj-honeycomb | A Clojure interface to Honeycomb.io, built on libhoney-java. | https://github.com/conormcd/clj-honeycomb |


### PR DESCRIPTION
A Clojure interface to Honeycomb.io, built on libhoney-java.

https://github.com/conormcd/clj-honeycomb

I've a second commit here to alphabetise the list. I can drop that commit and/or move it to a separate PR if you'd like.