### PR TITLE
Adding Honeycomb-MSTeams-Wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ If you'd like to add your own project, please file a pull request doing so.
 | go-honeycombio | Go client for the Honeycomb management APIs (everything except events) | https://github.com/kvrhdn/go-honeycombio 
 | workers-honeycomb-logger | Capture Cloudflare worker metadata | https://github.com/cloudflare/workers-honeycomb-logger
 | logback-honeycomb-appender | Java SLF4J Appender that writes to Honeycomb and can write SpanEvents for tracing | https://tersesystems.github.io/terse-logback/guide/tracing/
+| honeycomb-wrapper-msteams | The Honeycomb Wrapper is designed to push notifications from Honeycomb UI to Microsoft Teams Channel | https://github.com/Wellsky-OpenSource/honeycomb-wrapper-msteams.git


### PR DESCRIPTION
Adding [Honeycomb-MSTeams-Wrapper](https://github.com/Wellsky-OpenSource/honeycomb-wrapper-msteams.git)