### PR TITLE
feat: Add rust_opentelemetry_honeycomb

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ If you'd like to add your own project, please file a pull request doing so.
 
 | Project Name                         | Description                                                                                                  | Link                                                                |
 |--------------------------------------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| rust_opentelemetry_honeycomb         | A sample Rust app showing how to send OpenTelemetry traces to Honeycomb. | https://github.com/Dhghomon/rust_opentelemetry_honeycomb |
 | HoneycombSerilogSink                 | Adds a [Serilog](https://serilog.net/) sink so you can push structured .NET logs to Honeycomb.               | https://github.com/evilpilaf/HoneycombSerilogSink                   |
 | dynsampler-rb                        | An implementation of [dynsampler-go](https://github.com/honeycombio/dynsampler-go) written in Ruby.          | https://github.com/travis-ci/dynsampler-rb                          |
 | spinsible-honeycomb                  | Ansible roles and config for Honeycomb.                                                                      | https://github.com/getspine/spinesible-honeycomb                    |


### PR DESCRIPTION
Since we don't have docs/samples for Rust, and someone kindly put that together in a nice easy-to-understand app, adding a link to it